### PR TITLE
Multifile

### DIFF
--- a/country_collator_iris.py
+++ b/country_collator_iris.py
@@ -113,7 +113,8 @@ def catdata(catlist,outfil,durflg=0):
 
     iris.fileformats.netcdf.save(cubes2, outfil)
 
-    cubes, cubes2 = None
+    cubes = None
+    cubes2 = None
 
 def combinedata(outpath,country):
 

--- a/glamdicts.py
+++ b/glamdicts.py
@@ -15,10 +15,10 @@ countries={
         "zambia":3
         }
 crops={
-      "maize":0,
-      "potato":1,
-      "soybean":2,
-      "groundnut":3,
+      "maize":2,
+      "potato":0,
+      "soybean":3,
+      "groundnut":1,
       "cassava":4,
       "rice":5,
       "sorghum":6,


### PR DESCRIPTION
Modified the file creation system to consolidate files into eight files per country, with four fields per file. Iris is now used rather than NCO due to issues with the recorded dimension. Batch scripts also added which can be used to consolidate data after the year_collator.py script has been used